### PR TITLE
Reduce Fail2Ban's GID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -267,7 +267,7 @@ RUN case "$(cat /etc/os-release | grep VERSION_ID | cut -d = -f 2 | cut -d . -f 
     #mv promtail /usr/sbin && \
     \
     ### Fail2ban Configuration
-    addgroup -g 65550 fail2ban && \
+    addgroup -g 65500 fail2ban && \
     addgroup zabbix fail2ban && \
     rm -rf /var/run/fail2ban && \
     mkdir -p /var/run/fail2ban && \


### PR DESCRIPTION
Fail2Ban's GID is too large for LXC Containers and will fail on extraction/pull in those environments.
I do not have a Fail2Ban instance to test this on, however I was able to build the image on my LXC container with no issues, and I was able to load the image without any issue. If you are able to test this with a Fail2Ban instance in order to make sure that functionality isn't broken, then I believe this should fix #59  .