### PR TITLE
Fix a typo in the Docker URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Clone this repository and build the image with `docker build <arguments> (imagen
 Builds of the image are available on [Docker Hub](https://hub.docker.com/r/tiredofit/alpine)
 
 ```bash
-docker pull docker.io/tiredofdit/alpine:(imagetag)
+docker pull docker.io/tiredofit/alpine:(imagetag)
 ```
 
 Builds of the image are also available on the [Github Container Registry](https://github.com/tiredofit/docker-alpine/pkgs/container/docker-alpine)


### PR DESCRIPTION
There is a typo in the Docker URL in README.md